### PR TITLE
Remove Double encoding of URI

### DIFF
--- a/lib/kinetic_sdk/core/lib/webhooks.rb
+++ b/lib/kinetic_sdk/core/lib/webhooks.rb
@@ -196,7 +196,7 @@ module KineticSdk
     # @return [KineticSdk::Utils::KineticHttpResponse] object, with +code+, +message+, +content_string+, and +content+ properties
     def delete_webhook_on_kapp(kapp_slug, name, headers=default_headers)
       @logger.info("Deleting the #{name} webhook on the #{kapp_slug}\ kapp.")
-      delete(URI.encode("#{@api_url}/kapps/#{kapp_slug}/webhooks/#{encode(name)}"), headers)
+      delete("#{@api_url}/kapps/#{kapp_slug}/webhooks/#{encode(name)}", headers)
     end
 
     # Delete a webhook on space


### PR DESCRIPTION
The uri for the delete_webhook_on_kapp was being encoded twice, which was causing a failure in the method.  A space was being converted twice and therefore to %2520