### PR TITLE
Update kinetic-export-utils.rb

### DIFF
--- a/lib/kinetic_sdk/utils/kinetic-export-utils.rb
+++ b/lib/kinetic_sdk/utils/kinetic-export-utils.rb
@@ -140,11 +140,12 @@ module KineticSdk
 
         # If this is not the "root" object
         if object_path != '' && !file_contents.empty?
-          # Remove all `/` and `\` characters with ``
+          # Replace all `/` and `\` characters with `-`
+          # Replace multiple spaces with single space.
           # Replace all `.` with `/`
           # Replace all `::` with `-` (this ensures nested Teams/Categories maintain a separator)
           # Replace all non-slug characters with ``
-          filename = "#{core_path}/#{object_path.gsub('/\\', '').gsub('.', '/').gsub(/::/, '-').gsub(/[^ a-zA-Z0-9_\-\/]/, '')}.json"
+          filename = "#{core_path}/#{object_path.gsub(/(\/)|(\\)/, '-').gsub(/\s{2,}/, ' ').gsub('.', '/').gsub(/::/, '-').gsub(/[^ a-zA-Z0-9_\-\/]/, '')}.json"
           # Write the file_contents based upon the
           write_object_to_file(filename, file_contents)
         end


### PR DESCRIPTION
Forward slashes were not getting escaped.  Added check for double spaces as "foo \ bar" was then being replaced with "foo  bar" (has two spaces).  Now will be "foo bar" (has one space.